### PR TITLE
Convert facebook/react to GitHub Actions

### DIFF
--- a/.github/actions/setup_node_modules/action.yml
+++ b/.github/actions/setup_node_modules/action.yml
@@ -1,0 +1,24 @@
+name: setup_node_modules
+runs:
+  using: composite
+  steps:
+  - name: restore_cache
+    uses: actions/cache@v3.3.2
+    with:
+      key: v2-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}
+      path: UPDATE_ME
+      restore-keys: v2-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}
+  - name: Install dependencies
+    run: |-
+      yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
+      if [ $? -ne 0 ]; then
+        yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
+      fi
+    env:
+      ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+    shell: bash
+  - name: save_cache
+    uses: actions/cache@v3.3.2
+    with:
+      path: "~/.cache/yarn"
+      key: v2-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,328 @@
+name: facebook/react/build_and_test
+on:
+  workflow_dispatch:
+    inputs:
+      prerelease_commit_sha:
+        required: true
+env:
+  CIRCLE_CI_API_TOKEN: xxxx6989
+  NPM_TOKEN: xxxxJBvP
+jobs:
+  yarn_flow:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }} && github.ref != 'refs/heads/builds/facebook-www'
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/setup_node_modules"
+    - run: node ./scripts/tasks/flow-ci
+  check_generated_fizz_runtime:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }} && github.ref != 'refs/heads/builds/facebook-www'
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        path: build
+    - uses: "./.github/actions/setup_node_modules"
+    - name: Confirm generated inline Fizz runtime is up to date
+      run: |-
+        yarn generate-inline-fizz-runtime
+        git diff --quiet || (echo "There was a change to the Fizz runtime. Run `yarn generate-inline-fizz-runtime` and check in the result." && false)
+  yarn_lint:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }} && github.ref != 'refs/heads/builds/facebook-www'
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/setup_node_modules"
+    - run: node ./scripts/prettier/index
+    - run: node ./scripts/tasks/eslint
+    - run: "./scripts/circleci/check_license.sh"
+    - run: "./scripts/circleci/check_modules.sh"
+    - run: "./scripts/circleci/test_print_warnings.sh"
+  yarn_test:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }} && github.ref != 'refs/heads/builds/facebook-www'
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    strategy:
+      matrix:
+        args:
+        - "-r=stable --env=development"
+        - "-r=stable --env=production"
+        - "-r=experimental --env=development"
+        - "-r=experimental --env=production"
+        - "-r=www-classic --env=development --variant=false"
+        - "-r=www-classic --env=production --variant=false"
+        - "-r=www-classic --env=development --variant=true"
+        - "-r=www-classic --env=production --variant=true"
+        - "-r=www-modern --env=development --variant=false"
+        - "-r=www-modern --env=production --variant=false"
+        - "-r=www-modern --env=development --variant=true"
+        - "-r=www-modern --env=production --variant=true"
+        - "-r=stable --env=development --persistent"
+        - "-r=experimental --env=development --persistent"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/setup_node_modules"
+    - run: yarn test ${{ matrix.args }} --ci
+  yarn_build:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }} && github.ref != 'refs/heads/builds/facebook-www'
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/setup_node_modules"
+    - run: yarn build
+    - uses: actions/upload-artifact@v3.1.3
+      with:
+        path: "./build"
+  scrape_warning_messages:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }} && github.ref != 'refs/heads/builds/facebook-www'
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/setup_node_modules"
+    - run: |-
+        mkdir -p ./build
+        node ./scripts/print-warnings/print-warnings.js > build/WARNINGS
+    - uses: actions/upload-artifact@v3.1.3
+      with:
+        path: "./build"
+  process_artifacts_combined:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }}
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    needs:
+    - scrape_warning_messages
+    - yarn_build
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        path: "."
+    - uses: "./.github/actions/setup_node_modules"
+    - run: "echo \"<< pipeline.git.revision\t>>\" >> build/COMMIT_SHA"
+    - run: tar -zcvf ./build.tgz ./build
+    - run: cp ./build.tgz ./build2.tgz
+    - uses: actions/upload-artifact@v3.1.3
+      with:
+        path: "./build2.tgz"
+    - uses: actions/upload-artifact@v3.1.3
+      with:
+        path: "./build.tgz"
+  yarn_test_build:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }}
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    needs:
+    - yarn_build
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    strategy:
+      matrix:
+        args:
+        - "-r=stable --env=development"
+        - "-r=stable --env=production"
+        - "-r=experimental --env=development"
+        - "-r=experimental --env=production"
+        - "--project=devtools -r=experimental"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        path: "."
+    - uses: "./.github/actions/setup_node_modules"
+    - run: yarn test --build ${{ matrix.args }} --ci
+  download_base_build_for_sizebot:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }} && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/builds/facebook-www'
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/setup_node_modules"
+    - name: Download artifacts for base revision
+      run: |-
+        git fetch origin main
+        cd ./scripts/release && yarn && cd ../../
+        scripts/release/download-experimental-build.js --commit=$(git merge-base HEAD origin/main) --allowBrokenCI
+        mv ./build ./base-build
+    - name: Delete extraneous files
+      run: rm -rf ./base-build/node_modules
+    - uses: actions/upload-artifact@v3.1.3
+      with:
+        path: "./base-build"
+  sizebot:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }} && github.ref != 'refs/heads/main'
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    needs:
+    - download_base_build_for_sizebot
+    - yarn_build
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        path: "."
+    - run: "echo \"<< pipeline.git.revision\t>>\" >> build/COMMIT_SHA"
+    - uses: "./.github/actions/setup_node_modules"
+    - run: node ./scripts/tasks/danger
+  yarn_lint_build:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }}
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    needs:
+    - yarn_build
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        path: "."
+    - uses: "./.github/actions/setup_node_modules"
+    - run: yarn lint-build
+  yarn_check_release_dependencies:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }}
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    needs:
+    - yarn_build
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        path: "."
+    - uses: "./.github/actions/setup_node_modules"
+    - run: yarn check-release-dependencies
+  check_error_codes:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }}
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    needs:
+    - yarn_build
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        path: build
+    - uses: "./.github/actions/setup_node_modules"
+    - name: Search build artifacts for unminified errors
+      run: |-
+        yarn extract-errors
+        git diff --quiet || (echo "Found unminified errors. Either update the error codes map or disable error minification for the affected build, if appropriate." && false)
+  RELEASE_CHANNEL_stable_yarn_test_dom_fixtures:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }}
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    needs:
+    - yarn_build
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        path: "."
+    - uses: "./.github/actions/setup_node_modules"
+    - name: restore_cache
+      uses: actions/cache@v3.3.2
+      with:
+        key: v2-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}-fixtures/dom
+        path: "~/.cache/yarn"
+        restore-keys: v2-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}-fixtures/dom
+    - name: Install dependencies in fixtures/dom
+      run: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
+      working-directory: fixtures/dom
+    - name: Install dependencies in fixtures/dom (retry)
+      run: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
+      working-directory: fixtures/dom
+      if: failure()
+    - name: Run DOM fixture tests
+      run: |-
+        yarn predev
+        yarn test --maxWorkers=2
+      working-directory: fixtures/dom
+      env:
+        RELEASE_CHANNEL: stable
+  build_devtools_and_process_artifacts:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }}
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    needs:
+    - yarn_build
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        path: "."
+    - uses: "./.github/actions/setup_node_modules"
+    - run: "./scripts/circleci/pack_and_store_devtools_artifacts.sh"
+      env:
+        RELEASE_CHANNEL: experimental
+    - uses: actions/upload-artifact@v3.1.3
+      with:
+        path: "./build/devtools.tgz"
+  run_devtools_e2e_tests:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }}
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    needs:
+    - build_devtools_and_process_artifacts
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        path: "."
+    - uses: "./.github/actions/setup_node_modules"
+    - name: Playwright install deps
+      run: |-
+        npx playwright install
+        sudo npx playwright install-deps
+    - run: "./scripts/circleci/run_devtools_e2e_tests.js"
+      env:
+        RELEASE_CHANNEL: experimental

--- a/.github/workflows/devtools_regression_tests.yml
+++ b/.github/workflows/devtools_regression_tests.yml
@@ -1,0 +1,114 @@
+name: facebook/react/devtools_regression_tests
+on:
+  schedule:
+  - cron: 0 0 * * *
+#   # 'filters' was not transformed because there is no suitable equivalent in GitHub Actions
+  workflow_dispatch:
+    inputs:
+      prerelease_commit_sha:
+        required: true
+env:
+  CIRCLE_CI_API_TOKEN: xxxx6989
+  NPM_TOKEN: xxxxJBvP
+jobs:
+  download_build:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }}
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+      revision: "${{ github.event.pull_request.head.sha }}"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/setup_node_modules"
+    - name: Download artifacts for revision
+      run: |-
+        git fetch origin main
+        cd ./scripts/release && yarn && cd ../../
+        scripts/release/download-experimental-build.js --commit=${{ env.revision }} --allowBrokenCI
+    - uses: actions/upload-artifact@v3.1.3
+      with:
+        path: "./build"
+  build_devtools_and_process_artifacts:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }}
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    needs:
+    - download_build
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        path: "."
+    - uses: "./.github/actions/setup_node_modules"
+    - run: "./scripts/circleci/pack_and_store_devtools_artifacts.sh"
+      env:
+        RELEASE_CHANNEL: experimental
+    - uses: actions/upload-artifact@v3.1.3
+      with:
+        path: "./build/devtools.tgz"
+  run_devtools_tests_for_versions:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }}
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    needs:
+    - build_devtools_and_process_artifacts
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    strategy:
+      matrix:
+        version:
+        - '16.0'
+        - '16.5'
+        - '16.8'
+        - '17.0'
+        - '18.0'
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        path: "."
+    - uses: "./.github/actions/setup_node_modules"
+    - run: "./scripts/circleci/download_devtools_regression_build.js ${{ matrix.version }} --replaceBuild"
+    - run: node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion ${{ matrix.version }} --ci
+  run_devtools_e2e_tests_for_versions:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }}
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    needs:
+    - build_devtools_and_process_artifacts
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    strategy:
+      matrix:
+        version:
+        - '16.0'
+        - '16.5'
+        - '16.8'
+        - '17.0'
+        - '18.0'
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/download-artifact@v3.0.2
+      with:
+        path: "."
+    - uses: "./.github/actions/setup_node_modules"
+    - name: Playwright install deps
+      run: |-
+        npx playwright install
+        sudo npx playwright install-deps
+    - run: "./scripts/circleci/download_devtools_regression_build.js ${{ matrix.version }}"
+    - run: "./scripts/circleci/run_devtools_e2e_tests.js ${{ matrix.version }}"
+      env:
+        RELEASE_CHANNEL: experimental
+    - name: Cleanup build regression folder
+      run: rm -r ./build-regression
+    - uses: actions/upload-artifact@v3.1.3
+      with:
+        path: "./tmp/screenshots"

--- a/.github/workflows/fuzz_tests.yml
+++ b/.github/workflows/fuzz_tests.yml
@@ -1,0 +1,27 @@
+name: facebook/react/fuzz_tests
+on:
+  schedule:
+  - cron: 0 * * * *
+#   # 'filters' was not transformed because there is no suitable equivalent in GitHub Actions
+  workflow_dispatch:
+    inputs:
+      prerelease_commit_sha:
+        required: true
+env:
+  CIRCLE_CI_API_TOKEN: xxxx6989
+  NPM_TOKEN: xxxxJBvP
+jobs:
+  test_fuzz:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }}
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/setup_node_modules"
+    - name: Run fuzz tests
+      run: |-
+        FUZZ_TEST_SEED=$RANDOM yarn test fuzz --ci
+        FUZZ_TEST_SEED=$RANDOM yarn test --prod fuzz --ci

--- a/.github/workflows/publish_preleases.yml
+++ b/.github/workflows/publish_preleases.yml
@@ -1,0 +1,52 @@
+name: facebook/react/publish_preleases
+on:
+  workflow_dispatch:
+    inputs:
+      prerelease_commit_sha:
+        required: true
+env:
+  CIRCLE_CI_API_TOKEN: xxxx6989
+  NPM_TOKEN: xxxxJBvP
+jobs:
+  publish_prerelease:
+    if: ${{ inputs.prerelease_commit_sha }}
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+      commit_sha: "${{ inputs.prerelease_commit_sha }}"
+      release_channel: stable
+      dist_tag: canary,next
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/setup_node_modules"
+    - name: Run publish script
+      run: |-
+        git fetch origin main
+        cd ./scripts/release && yarn && cd ../../
+        scripts/release/prepare-release-from-ci.js --skipTests -r ${{ env.release_channel }} --commit=${{ env.commit_sha }}
+        cp ./scripts/release/ci-npmrc ~/.npmrc
+        scripts/release/publish.js --ci --tags ${{ env.dist_tag }}
+  publish_prerelease_1:
+    if: ${{ inputs.prerelease_commit_sha }}
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    needs:
+    - Publish to Canary channel
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+      commit_sha: "${{ inputs.prerelease_commit_sha }}"
+      release_channel: experimental
+      dist_tag: experimental
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/setup_node_modules"
+    - name: Run publish script
+      run: |-
+        git fetch origin main
+        cd ./scripts/release && yarn && cd ../../
+        scripts/release/prepare-release-from-ci.js --skipTests -r ${{ env.release_channel }} --commit=${{ env.commit_sha }}
+        cp ./scripts/release/ci-npmrc ~/.npmrc
+        scripts/release/publish.js --ci --tags ${{ env.dist_tag }}

--- a/.github/workflows/publish_preleases_nightly.yml
+++ b/.github/workflows/publish_preleases_nightly.yml
@@ -1,0 +1,55 @@
+name: facebook/react/publish_preleases_nightly
+on:
+  schedule:
+  - cron: 10 16 * * 1,2,3,4,5
+#   # 'filters' was not transformed because there is no suitable equivalent in GitHub Actions
+  workflow_dispatch:
+    inputs:
+      prerelease_commit_sha:
+        required: true
+env:
+  CIRCLE_CI_API_TOKEN: xxxx6989
+  NPM_TOKEN: xxxxJBvP
+jobs:
+  publish_prerelease:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }}
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+      commit_sha: "${{ github.event.pull_request.head.sha }}"
+      release_channel: stable
+      dist_tag: canary,next
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/setup_node_modules"
+    - name: Run publish script
+      run: |-
+        git fetch origin main
+        cd ./scripts/release && yarn && cd ../../
+        scripts/release/prepare-release-from-ci.js --skipTests -r ${{ env.release_channel }} --commit=${{ env.commit_sha }}
+        cp ./scripts/release/ci-npmrc ~/.npmrc
+        scripts/release/publish.js --ci --tags ${{ env.dist_tag }}
+  publish_prerelease_1:
+    if: ${{ !(${{ inputs.prerelease_commit_sha }}) }}
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/openjdk:18.0-node
+    needs:
+    - Publish to Canary channel
+    env:
+      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+      commit_sha: "${{ github.event.pull_request.head.sha }}"
+      release_channel: experimental
+      dist_tag: experimental
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/setup_node_modules"
+    - name: Run publish script
+      run: |-
+        git fetch origin main
+        cd ./scripts/release && yarn && cd ../../
+        scripts/release/prepare-release-from-ci.js --skipTests -r ${{ env.release_channel }} --commit=${{ env.commit_sha }}
+        cp ./scripts/release/ci-npmrc ~/.npmrc
+        scripts/release/publish.js --ci --tags ${{ env.dist_tag }}


### PR DESCRIPTION
Pipeline migrated from [CircleCI](https://app.circleci.com/pipelines/github/facebook/react) :tada:

## Manual steps

Perform the following steps to complete the migration:

### facebook/react/build_and_test
- [ ] Ensure environment variable is updated: `CIRCLE_CI_API_TOKEN`
- [ ] Ensure environment variable is updated: `NPM_TOKEN`

### facebook/react/fuzz_tests
- [ ] Ensure environment variable is updated: `CIRCLE_CI_API_TOKEN`
- [ ] Ensure environment variable is updated: `NPM_TOKEN`

### facebook/react/devtools_regression_tests
- [ ] Ensure environment variable is updated: `CIRCLE_CI_API_TOKEN`
- [ ] Ensure environment variable is updated: `NPM_TOKEN`

### facebook/react/publish_preleases
- [ ] Ensure environment variable is updated: `CIRCLE_CI_API_TOKEN`
- [ ] Ensure environment variable is updated: `NPM_TOKEN`

### facebook/react/publish_preleases_nightly
- [ ] Ensure environment variable is updated: `CIRCLE_CI_API_TOKEN`
- [ ] Ensure environment variable is updated: `NPM_TOKEN`